### PR TITLE
Add support for explicit big-/little-endian primitives

### DIFF
--- a/src/gloss/data/primitives.clj
+++ b/src/gloss/data/primitives.clj
@@ -14,7 +14,8 @@
   (:import
     [java.nio
      Buffer
-     ByteBuffer]))
+     ByteBuffer
+     ByteOrder]))
 
 (defn has-bytes [n buf-seq]
   (< (.remaining ^Buffer (first buf-seq)) n))
@@ -64,46 +65,78 @@
   [x]
   (.longValue (bigint x)))
 
+(def byte-order
+  {:le ByteOrder/LITTLE_ENDIAN
+   :be ByteOrder/BIG_ENDIAN
+   :ne (ByteOrder/nativeOrder)})
 
-(defmacro primitive-codec [accessor writer size get-transform typecast put-transform]
-  `(reify
-     Reader
-     (read-bytes [this# b#]
-       (if (< (byte-count b#) ~size)
-         [false this# b#]
-         (let [first-buf# (first b#)
-               remaining# (.remaining ^Buffer first-buf#)]
-           (cond
-             (= ~size remaining#)
-             [true
-              (~get-transform (~accessor ^ByteBuffer first-buf#))
-              (rest b#)]
+(defmacro with-byte-order [[buf bo] & body]
+  (if (nil? bo)
+    `(do ~@body)
+    `(let [^ByteBuffer buf# ~buf, obo# (.order buf#)]
+       (try
+         (.order buf# (byte-order ~bo))
+         ~@body
+         (finally
+          (.order buf# obo#))))))
 
-             (< ~size remaining#)
-             [true
-              (~get-transform (~accessor ^ByteBuffer first-buf#))
-              (-> b# rewind-bytes (drop-bytes ~size))]
+(defmacro primitive-codec
+  [accessor writer size get-transform typecast put-transform & optional]
+  (let [[bo] optional]
+    `(reify
+       Reader
+       (read-bytes [this# b#]
+         (if (< (byte-count b#) ~size)
+           [false this# b#]
+           (let [first-buf# (first b#)
+                 remaining# (.remaining ^Buffer first-buf#)]
+             (cond
+              (= ~size remaining#)
+              [true
+               (with-byte-order [first-buf# ~bo]
+                 (~get-transform (~accessor ^ByteBuffer first-buf#)))
+               (rest b#)]
 
-             :else
-             (let [buf# (take-contiguous-bytes b# ~size)]
-               [true
-                (~get-transform (~accessor ^ByteBuffer buf#))
-                (drop-bytes b# ~size)])))))
-     Writer
-     (sizeof [_]
-       ~size)
-     (write-bytes [_ buf# v#]
-       (with-buffer [buf# ~size]
-         (~writer ^ByteBuffer buf# (~typecast (~put-transform v#)))))))
+              (< ~size remaining#)
+              [true
+               (with-byte-order [first-buf# ~bo]
+                 (~get-transform (~accessor ^ByteBuffer first-buf#)))
+               (-> b# rewind-bytes (drop-bytes ~size))]
+
+              :else
+              (let [buf# (take-contiguous-bytes b# ~size)]
+                [true
+                 (with-byte-order [buf# ~bo]
+                   (~get-transform (~accessor ^ByteBuffer buf#)))
+                 (drop-bytes b# ~size)])))))
+       Writer
+       (sizeof [_]
+         ~size)
+       (write-bytes [_ buf# v#]
+         (with-buffer [buf# ~size]
+           (with-byte-order [buf# ~bo]
+             (~writer ^ByteBuffer buf# (~typecast (~put-transform v#)))))))))
 
 (def primitive-codecs
   {:byte (primitive-codec .get .put 1 identity byte to-byte)
    :int16 (primitive-codec .getShort .putShort 2 identity short identity)
+   :int16-le (primitive-codec .getShort .putShort 2 identity short identity :le)
+   :int16-be (primitive-codec .getShort .putShort 2 identity short identity :be)
    :int32 (primitive-codec .getInt .putInt 4 identity int identity)
+   :int32-le (primitive-codec .getInt .putInt 4 identity int identity :le)
+   :int32-be (primitive-codec .getInt .putInt 4 identity int identity :be)
    :int64 (primitive-codec .getLong .putLong 8 identity long identity)
+   :int64-le (primitive-codec .getLong .putLong 8 identity long identity :le)
+   :int64-be (primitive-codec .getLong .putLong 8 identity long identity :be)
    :float32 (primitive-codec .getFloat .putFloat 4 identity float identity)
    :float64 (primitive-codec .getDouble .putDouble 8 identity double identity)
    :ubyte (primitive-codec .get .put 1 byte->ubyte byte ubyte->byte)
    :uint16 (primitive-codec .getShort .putShort 2 short->ushort short ushort->short)
+   :uint16-le (primitive-codec .getShort .putShort 2 short->ushort short ushort->short :le)
+   :uint16-be (primitive-codec .getShort .putShort 2 short->ushort short ushort->short :be)
    :uint32 (primitive-codec .getInt .putInt 4 int->uint int uint->int)
-   :uint64 (primitive-codec .getLong .putLong 8 long->ulong long ulong->long)})
+   :uint32-le (primitive-codec .getInt .putInt 4 int->uint int uint->int :le)
+   :uint32-be (primitive-codec .getInt .putInt 4 int->uint int uint->int :be)
+   :uint64 (primitive-codec .getLong .putLong 8 long->ulong long ulong->long)
+   :uint64-le (primitive-codec .getLong .putLong 8 long->ulong long ulong->long :le)
+   :uint64-be (primitive-codec .getLong .putLong 8 long->ulong long ulong->long :be)})


### PR DESCRIPTION
You've got this on the gloss TODO list, but here's a quick hack which at least makes it possible to represent little-endian values.  I see you have a commit which preserves the byte-order of ByteBuffer instances moving through gloss, but couldn't figure out how to specify that byte-order in the first place...

If this isn't how you envision explicit endianess working, I'd be perfectly happy to re-work.
