### PR TITLE
Default field value support

### DIFF
--- a/src/gloss/core.clj
+++ b/src/gloss/core.clj
@@ -267,3 +267,16 @@
       (codecs/wrap-prefixed-sequence
 	(or (compile-frame (:prefix options)) (:int32 primitive-codecs))
 	codec))))
+
+(defn default
+  [frame default-value]
+  (let [codec (compile-frame frame)]
+    (reify
+      Reader
+      (read-bytes [_ b]
+        (read-bytes codec b))
+      Writer
+      (sizeof [_]
+        (sizeof codec))
+      (write-bytes [_ buf vs]
+        (write-bytes codec buf (or vs default-value))))))

--- a/test/gloss/test/core.clj
+++ b/test/gloss/test/core.clj
@@ -298,3 +298,32 @@
 	dec)
       (string :utf-8 :suffix ","))
     "abc"))
+
+(deftest test-default-values
+  (letfn [(test-default [codec before after]
+            (is= (decode codec (encode codec before))
+                 after))]
+    (test-default {:a :byte :b (default :byte 7)}
+                  {:a 3}
+                  {:a 3 :b 7})
+    (let [complex {:a :byte :b (default (repeated :int32 :prefix :none) [1 2 3])}]
+      (test-default complex
+                    {:a 5}
+                    {:a 5 :b [1 2 3]})
+      (test-default complex
+                    {:a 8 :b [4 5 6]}
+                    {:a 8 :b [4 5 6]}))
+    (let [complex-str {:a :byte :b (default (string :utf-8) "def")}]
+      (test-default complex-str
+                    {:a 9}
+                    {:a 9 :b "def"})
+      (test-default complex-str
+                    {:a 9 :b "string"}
+                    {:a 9 :b "string"}))
+    (let [plain-str (default (string :utf-8) "def")]
+      (test-default plain-str
+                    nil
+                    "def")
+      (test-default plain-str
+                    "string"
+                    "string"))))


### PR DESCRIPTION
Patch to add default field value support.

Example:

 (defcodec example {:a :int32 :b (default :int32 7)})
 (encode example {:a 4})
 (decode example *1) => {:a 4 :b 7}

Also, it works with nested types:

 (defcodec example {:a :int32 :b (default (repeated :int32 :prefix :none) [1 2 3])})
 (encode example {:a 4})
 (decode example *1) => {:a 4 :b [1 2 3]}
