### PR TITLE
Avoid unnecessary duplicates in take-contiguous-bytes

### DIFF
--- a/src/gloss/data/bytes/core.clj
+++ b/src/gloss/data/bytes/core.clj
@@ -160,7 +160,6 @@
 
   (take-contiguous-bytes- [this n]
     (let [n (min byte-count n)
-	  buf-seq (map duplicate buf-seq)
 	  first-buf ^ByteBuffer (first buf-seq)]
       (if (> (.remaining first-buf) n)
 	(-> first-buf duplicate ^ByteBuffer (.limit (+ (.position first-buf) n)) slice)


### PR DESCRIPTION
I'm not 100% sure, but it looks like the old code is duplicating all of the buffers once and then duplicating each buffer it visits in the loop again.
