### PR TITLE
Update byte-streams and fix gloss.data.bytes.delimited/match-loop eval

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"
             :distribution :repo}
   :dependencies [[manifold/manifold "0.2.3"]
-                 [org.clj-commons/byte-streams "0.2.10"]
+                 [org.clj-commons/byte-streams "0.3.0"]
                  [potemkin/potemkin "0.4.5"]]
 
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.10.3"]]}}

--- a/src/gloss/core/formats.clj
+++ b/src/gloss/core/formats.clj
@@ -9,7 +9,7 @@
 (ns ^{:skip-wiki true}
   gloss.core.formats
   (:require
-    [byte-streams :as bs])
+    [clj-commons.byte-streams :as bs])
   (:use
     [gloss.data.bytes.core])
   (:import

--- a/src/gloss/data/bytes/delimited.clj
+++ b/src/gloss/data/bytes/delimited.clj
@@ -66,34 +66,30 @@
 	    [[(or (last dimensions) 0)
 	      (last buf-seq)]]))))))
 
-(defn delimiter-matcher [delimiter max-delimiter-length]
-  (let [delimiter (byte-buffer->byte-seq delimiter)]
-    `(do
-       (.position ~'buf ~'pos)
-       (and
-	~@(when (< 1 max-delimiter-length)
-	    [`(<= ~'pos (or ~'final-position
-			  (unchecked-subtract ~'buf-length ~(count delimiter))))])
-	~@(map
-	    (fn [val] `(== ~(int val) (int (.get ~'buf))))
-	    delimiter)))))
-
 (defn match-loop [delimiters strip-delimiters?]
   (let [delimiters (sort-delimiters delimiters)
-	max-delimiter-length (.remaining ^ByteBuffer (first delimiters))]
-    (eval
-      (postwalk-replace
-	{'buf (with-meta 'buf {:tag "java.nio.ByteBuffer"})}
-	`(fn [~'buf last-and-complete?#]
-	   (let [~'buf-length (.remaining ~'buf)
-		 ~'final-position (when-not last-and-complete?#
-				    (unchecked-subtract ~'buf-length ~max-delimiter-length))]
-	     (loop [~'pos 0]
-	       (if (== ~'pos ~'buf-length)
-		 [false 0 0]
-		 (if (or ~@(map #(delimiter-matcher % max-delimiter-length) delimiters))
-		   [true ~(if strip-delimiters? 'pos `(.position ~'buf)) (.position ~'buf)]
-		   (recur (unchecked-inc ~'pos)))))))))))
+        max-delimiter-length (.remaining ^ByteBuffer (first delimiters))]
+    (fn [^java.nio.ByteBuffer buf last-and-complete?]
+      (let [buf-length (.remaining buf)
+            final-position (when-not last-and-complete?
+                             (unchecked-subtract buf-length max-delimiter-length))]
+        (loop [pos 0]
+          (if (== pos buf-length)
+            [false 0 0]
+            (if (some
+                  (fn [delimiter]
+                    (let [delimiter (byte-buffer->byte-seq delimiter)]
+                      (.position buf pos)
+                      (and
+                        (or (not (< 1 max-delimiter-length))
+                            (<= pos (or final-position
+                                        (unchecked-subtract buf-length (count delimiter)))))
+                        (every?
+                          (fn [val] (== (int val) (int (.get buf))))
+                          delimiter))))
+                  delimiters)
+              [true (if strip-delimiters? pos (.position buf)) (.position buf)]
+              (recur (unchecked-inc pos)))))))))
 
 (def delimited-bytes-splitter
   (memoize

--- a/test/gloss/data/bytes/delimited_test.clj
+++ b/test/gloss/data/bytes/delimited_test.clj
@@ -1,0 +1,38 @@
+(ns gloss.data.bytes.delimited-test
+  (:require
+    [clojure.test :refer [deftest is testing]]
+    [gloss.data.bytes.delimited :as delimited])
+  (:import
+    (java.nio ByteBuffer)))
+
+
+
+(deftest match-loop
+  (testing "one"
+    (let [d1 (ByteBuffer/allocate 1)
+          ml (delimited/match-loop 
+               [d1]
+               false)]
+      (is (= [true 1 1]
+             (ml d1 true)))
+      (is (= [false 0 0]
+             (ml d1 false)))))
+  (testing "many"
+    (let [d1 (ByteBuffer/allocate 1)
+          d2 (ByteBuffer/allocate 2)
+          d3 (ByteBuffer/allocate 3)
+          ml (delimited/match-loop 
+               [d3 d2 d1]
+               false)]
+      (is (= [true 1 1]
+             (ml d1 true)))
+      (is (= [true 2 2]
+             (ml d2 true)))
+      (is (= [true 3 3]
+             (ml d3 true)))
+      (is (= [false 0 0]
+             (ml d1 false)))
+      (is (= [false 0 0]
+             (ml d2 false)))
+      (is (= [false 0 0]
+             (ml d3 false))))))


### PR DESCRIPTION
 Update byte-streams to 0.3.0 and use `clj-commons.byte-streams` namespace instead of `byte-streams`.

Rewrite [`gloss.data.bytes.delimited/match-loop`](https://github.com/clj-commons/gloss/blob/2cd038bb6d2343e7a8e3631e775e9da754c755dc/src/gloss/data/bytes/delimited.clj#L69-L96) to not use `eval`.


Tests
```
$ lein test

...

Ran 20 tests containing 3497 assertions.
0 failures, 0 errors.
```